### PR TITLE
Disabled Facilities dropdown until Governor is selected

### DIFF
--- a/scripts/Facilities.js
+++ b/scripts/Facilities.js
@@ -7,7 +7,7 @@ export const Facilities = () => {
   let html = "";
 
   html += '<label for="facilitySelect">Choose facility: </label>';
-  html += '<select id="facilitySelect">';
+  transientState.selectedGovernorId ? html += '<select id="facilitySelect">' : html += '<select disabled id="facilitySelect">'
   html += '<option value="0">Select a facility</option>';
 
   const arrayOfOptions = facilities.map((facility) => {


### PR DESCRIPTION
Added logic to Facilities dropdown to check whether or not a Governor is selected. If not, Facilities dropdown is disabled. Only becomes selectable after a Governor is chosen.

